### PR TITLE
Fix for sed on macos

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -41,13 +41,14 @@ do_release() {
 	local url=$(_upload_file ${tar_file})
 	# modify version and url for the release
 	# replace url
+	# read about the hack here - https://stackoverflow.com/a/44864004/1270865
 	sed -i.bak 's#url .*#url '\"${url}\"'#g' lazy-cow.rb && rm -f lazy-cow.rb.bak
 	# replace version
-	sed -i.bak 's/version .*/version '\"${tag}\"'/g' lazy-cow.rb && rm -f laz-cow.rb.bak
+	sed -i.bak 's/version .*/version '\"${tag}\"'/g' lazy-cow.rb && rm -f lazy-cow.rb.bak
 	# do a commit and push
 	_push_code $tag
 	# Surprise!
 	(/usr/games/fortune | /usr/games/cowsay) || true
 }
-
+[[ $OSTYPE == 'darwin'* ]] && echo "I wish this was a linux system... :(" || apt-get install fortune cowsay
 do_release


### PR DESCRIPTION
Sed causes an issue on macos. Although the release script isn't meant to be executed from here but still.
The summary of the issue is that macos comes bundled with a different kind of sed than what is available on debian.

Here is more detail about the issue.
https://stackoverflow.com/a/44864004/1270865