### PR TITLE
Ignore branch main for pushes so it doesn't run checks for every merge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: Pre-merge sanity checks
 # only trigger it when a pull request is opened
 on:
   push:
+    branches-ignore:
+      - main
   pull_request:
     branches-ignore:
       - main


### PR DESCRIPTION
Fixes #20 